### PR TITLE
Fixes to verilog files part 2.

### DIFF
--- a/cells/decap/sky130_fd_sc_hs__decap.symbol.v
+++ b/cells/decap/sky130_fd_sc_hs__decap.symbol.v
@@ -36,9 +36,9 @@ module sky130_fd_sc_hs__decap ();
 
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
+    supply1 VPB ;
+    supply0 VNB ;
 
 endmodule
 

--- a/cells/decap/sky130_fd_sc_hs__decap_4.blackbox.pp.v
+++ b/cells/decap/sky130_fd_sc_hs__decap_4.blackbox.pp.v
@@ -32,11 +32,11 @@
 
 (* blackbox *)
 module sky130_fd_sc_hs__decap_4 (
-);,
     VPWR,
     VGND,
     VPB ,
     VNB
+);
 
     input  VPWR;
     input  VGND;

--- a/cells/decap/sky130_fd_sc_hs__decap_4.blackbox.v
+++ b/cells/decap/sky130_fd_sc_hs__decap_4.blackbox.v
@@ -32,11 +32,12 @@
 
 (* blackbox *)
 module sky130_fd_sc_hs__decap_4 ();
+
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
+    supply1 VPB ;
+    supply0 VNB ;
 
 endmodule
 

--- a/cells/decap/sky130_fd_sc_hs__decap_4.functional.pp.v
+++ b/cells/decap/sky130_fd_sc_hs__decap_4.functional.pp.v
@@ -32,13 +32,18 @@
 `celldefine
 module sky130_fd_sc_hs__decap_4 (
     VGND,
-    VPWR
+    VPWR,
+    VPB ,
+    VNB
 );
 
     // Module ports
     input VGND;
     input VPWR;
-     // No contents.
+    input VPB;
+    input VNB;
+
+    // No contents.
 endmodule
 `endcelldefine
 

--- a/cells/decap/sky130_fd_sc_hs__decap_4.functional.v
+++ b/cells/decap/sky130_fd_sc_hs__decap_4.functional.v
@@ -31,13 +31,12 @@
 
 `celldefine
 module sky130_fd_sc_hs__decap_4 (
-    VGND
 );
 
-    // Module ports
-    supply0 VGND;
+    // No module ports
 
     // Module supplies
+    supply0 VGND;
     supply1 VPWR;
      // No contents.
 endmodule

--- a/cells/decap/sky130_fd_sc_hs__decap_4.timing.pp.v
+++ b/cells/decap/sky130_fd_sc_hs__decap_4.timing.pp.v
@@ -32,12 +32,17 @@
 `celldefine
 module sky130_fd_sc_hs__decap_4 (
     VGND,
-    VPWR
+    VPWR,
+    VPB ,
+    VNB
 );
 
     // Module ports
     input VGND;
     input VPWR;
+    input VPB;
+    input VNB;
+
      // No contents.
 endmodule
 `endcelldefine

--- a/cells/decap/sky130_fd_sc_hs__decap_4.timing.v
+++ b/cells/decap/sky130_fd_sc_hs__decap_4.timing.v
@@ -31,18 +31,10 @@
 
 `celldefine
 module sky130_fd_sc_hs__decap_4 (
-);,
-    VPWR,
-    VGND,
-    VPB ,
-    VNB
+);
 
-    // Module ports
-    input  VPWR;
-    input  VGND;
-    input  VPB ;
-    input  VNB ;
-     // No contents.
+    // No module ports
+    // No contents.
 endmodule
 `endcelldefine
 

--- a/cells/decap/sky130_fd_sc_hs__decap_8.blackbox.pp.v
+++ b/cells/decap/sky130_fd_sc_hs__decap_8.blackbox.pp.v
@@ -32,11 +32,11 @@
 
 (* blackbox *)
 module sky130_fd_sc_hs__decap_8 (
-);,
     VPWR,
     VGND,
     VPB ,
     VNB
+);,
 
     input  VPWR;
     input  VGND;

--- a/cells/decap/sky130_fd_sc_hs__decap_8.blackbox.v
+++ b/cells/decap/sky130_fd_sc_hs__decap_8.blackbox.v
@@ -32,11 +32,12 @@
 
 (* blackbox *)
 module sky130_fd_sc_hs__decap_8 ();
+
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
+    supply1 VPB ;
+    supply0 VNB ;
 
 endmodule
 

--- a/cells/decap/sky130_fd_sc_hs__decap_8.functional.pp.v
+++ b/cells/decap/sky130_fd_sc_hs__decap_8.functional.pp.v
@@ -32,12 +32,16 @@
 `celldefine
 module sky130_fd_sc_hs__decap_8 (
     VGND,
-    VPWR
+    VPWR,
+    VPB ,
+    VNB
 );
 
     // Module ports
     input VGND;
     input VPWR;
+    input VPB;
+    input VNB;
      // No contents.
 endmodule
 `endcelldefine

--- a/cells/decap/sky130_fd_sc_hs__decap_8.functional.v
+++ b/cells/decap/sky130_fd_sc_hs__decap_8.functional.v
@@ -31,15 +31,12 @@
 
 `celldefine
 module sky130_fd_sc_hs__decap_8 (
-    VGND
 );
 
-    // Module ports
-    supply0 VGND;
-
     // Module supplies
+    supply0 VGND;
     supply1 VPWR;
-     // No contents.
+    // No contents.
 endmodule
 `endcelldefine
 

--- a/cells/decap/sky130_fd_sc_hs__decap_8.timing.pp.v
+++ b/cells/decap/sky130_fd_sc_hs__decap_8.timing.pp.v
@@ -32,13 +32,17 @@
 `celldefine
 module sky130_fd_sc_hs__decap_8 (
     VGND,
-    VPWR
+    VPWR,
+    VPB ,
+    VNB ,
 );
 
     // Module ports
     input VGND;
     input VPWR;
-     // No contents.
+    input VPB;
+    input VNB;
+    // No contents.
 endmodule
 `endcelldefine
 

--- a/cells/decap/sky130_fd_sc_hs__decap_8.timing.v
+++ b/cells/decap/sky130_fd_sc_hs__decap_8.timing.v
@@ -31,18 +31,10 @@
 
 `celldefine
 module sky130_fd_sc_hs__decap_8 (
-);,
-    VPWR,
-    VGND,
-    VPB ,
-    VNB
+);
 
-    // Module ports
-    input  VPWR;
-    input  VGND;
-    input  VPB ;
-    input  VNB ;
-     // No contents.
+    // No module ports
+    // No contents.
 endmodule
 `endcelldefine
 

--- a/cells/diode/sky130_fd_sc_hs__diode.symbol.pp.v
+++ b/cells/diode/sky130_fd_sc_hs__diode.symbol.pp.v
@@ -35,11 +35,9 @@
 module sky130_fd_sc_hs__diode (
     //# {{power|Power}}
     input DIODE,
-    input VPB  ,
     input VPWR ,
-    input  VGND,
-    input  VPB ,
-    input  VNB
+    input VGND ,
+    input VPB  ,
     input VNB
 );
 endmodule

--- a/cells/diode/sky130_fd_sc_hs__diode_2.blackbox.pp.v
+++ b/cells/diode/sky130_fd_sc_hs__diode_2.blackbox.pp.v
@@ -37,8 +37,6 @@ module sky130_fd_sc_hs__diode_2 (
     VGND,
     VPB ,
     VNB
-    VPB  ,
-    VNB
 );
 
     input DIODE;
@@ -46,8 +44,6 @@ module sky130_fd_sc_hs__diode_2 (
     input VGND ;
     input  VPB ;
     input  VNB ;
-    input VPB  ;
-    input VNB  ;
 endmodule
 
 `default_nettype wire

--- a/cells/diode/sky130_fd_sc_hs__diode_2.functional.pp.v
+++ b/cells/diode/sky130_fd_sc_hs__diode_2.functional.pp.v
@@ -36,8 +36,6 @@ module sky130_fd_sc_hs__diode_2 (
     VGND,
     VPB ,
     VNB
-    VPB  ,
-    VNB
 );
 
     // Module ports
@@ -46,8 +44,6 @@ module sky130_fd_sc_hs__diode_2 (
     input VGND ;
     input  VPB ;
     input  VNB ;
-    input VPB  ;
-    input VNB  ;
      // No contents.
 endmodule
 `endcelldefine

--- a/cells/diode/sky130_fd_sc_hs__diode_2.functional.v
+++ b/cells/diode/sky130_fd_sc_hs__diode_2.functional.v
@@ -33,10 +33,16 @@
 module sky130_fd_sc_hs__diode_2 (
     DIODE
 );
-
     // Module ports
     input DIODE;
-     // No contents.
+
+    // Module supplies
+    supply1 VPWR;
+    supply0 VGND;
+    supply1 VPB;
+    supply0 VNB;
+
+    // No contents.
 endmodule
 `endcelldefine
 

--- a/cells/diode/sky130_fd_sc_hs__diode_2.timing.pp.v
+++ b/cells/diode/sky130_fd_sc_hs__diode_2.timing.pp.v
@@ -36,8 +36,6 @@ module sky130_fd_sc_hs__diode_2 (
     VGND,
     VPB ,
     VNB
-    VPB  ,
-    VNB
 );
 
     // Module ports
@@ -46,8 +44,6 @@ module sky130_fd_sc_hs__diode_2 (
     input VGND ;
     input  VPB ;
     input  VNB ;
-    input VPB  ;
-    input VNB  ;
      // No contents.
 endmodule
 `endcelldefine

--- a/cells/fill/sky130_fd_sc_hs__fill.symbol.pp.v
+++ b/cells/fill/sky130_fd_sc_hs__fill.symbol.pp.v
@@ -34,11 +34,9 @@
 (* blackbox *)
 module sky130_fd_sc_hs__fill (
     //# {{power|Power}}
-    input VPB ,
     input VPWR,
-    input  VGND,
-    input  VPB ,
-    input  VNB
+    input VGND,
+    input VPB ,
     input VNB
 );
 endmodule

--- a/cells/fill/sky130_fd_sc_hs__fill.symbol.v
+++ b/cells/fill/sky130_fd_sc_hs__fill.symbol.v
@@ -36,9 +36,7 @@ module sky130_fd_sc_hs__fill ();
 
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
 

--- a/cells/fill/sky130_fd_sc_hs__fill_1.blackbox.v
+++ b/cells/fill/sky130_fd_sc_hs__fill_1.blackbox.v
@@ -34,9 +34,7 @@
 module sky130_fd_sc_hs__fill_1 ();
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
 

--- a/cells/fill/sky130_fd_sc_hs__fill_1.functional.v
+++ b/cells/fill/sky130_fd_sc_hs__fill_1.functional.v
@@ -34,12 +34,11 @@ module sky130_fd_sc_hs__fill_1 ();
 
     // Module supplies
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
-     // No contents.
+
+    // No contents.
 endmodule
 `endcelldefine
 

--- a/cells/fill/sky130_fd_sc_hs__fill_1.timing.v
+++ b/cells/fill/sky130_fd_sc_hs__fill_1.timing.v
@@ -34,12 +34,11 @@ module sky130_fd_sc_hs__fill_1 ();
 
     // Module supplies
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
-     // No contents.
+
+    // No contents.
 endmodule
 `endcelldefine
 

--- a/cells/fill/sky130_fd_sc_hs__fill_2.blackbox.v
+++ b/cells/fill/sky130_fd_sc_hs__fill_2.blackbox.v
@@ -34,9 +34,7 @@
 module sky130_fd_sc_hs__fill_2 ();
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
 

--- a/cells/fill/sky130_fd_sc_hs__fill_2.functional.v
+++ b/cells/fill/sky130_fd_sc_hs__fill_2.functional.v
@@ -34,9 +34,7 @@ module sky130_fd_sc_hs__fill_2 ();
 
     // Module supplies
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
      // No contents.

--- a/cells/fill/sky130_fd_sc_hs__fill_2.timing.v
+++ b/cells/fill/sky130_fd_sc_hs__fill_2.timing.v
@@ -34,9 +34,7 @@ module sky130_fd_sc_hs__fill_2 ();
 
     // Module supplies
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
      // No contents.

--- a/cells/fill/sky130_fd_sc_hs__fill_4.blackbox.v
+++ b/cells/fill/sky130_fd_sc_hs__fill_4.blackbox.v
@@ -34,9 +34,7 @@
 module sky130_fd_sc_hs__fill_4 ();
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
 

--- a/cells/fill/sky130_fd_sc_hs__fill_4.functional.v
+++ b/cells/fill/sky130_fd_sc_hs__fill_4.functional.v
@@ -34,9 +34,7 @@ module sky130_fd_sc_hs__fill_4 ();
 
     // Module supplies
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
      // No contents.

--- a/cells/fill/sky130_fd_sc_hs__fill_4.timing.v
+++ b/cells/fill/sky130_fd_sc_hs__fill_4.timing.v
@@ -34,9 +34,7 @@ module sky130_fd_sc_hs__fill_4 ();
 
     // Module supplies
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
      // No contents.

--- a/cells/fill/sky130_fd_sc_hs__fill_8.blackbox.v
+++ b/cells/fill/sky130_fd_sc_hs__fill_8.blackbox.v
@@ -34,9 +34,7 @@
 module sky130_fd_sc_hs__fill_8 ();
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
 

--- a/cells/fill/sky130_fd_sc_hs__fill_8.functional.v
+++ b/cells/fill/sky130_fd_sc_hs__fill_8.functional.v
@@ -34,9 +34,7 @@ module sky130_fd_sc_hs__fill_8 ();
 
     // Module supplies
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
      // No contents.

--- a/cells/fill/sky130_fd_sc_hs__fill_8.timing.v
+++ b/cells/fill/sky130_fd_sc_hs__fill_8.timing.v
@@ -34,9 +34,7 @@ module sky130_fd_sc_hs__fill_8 ();
 
     // Module supplies
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
      // No contents.

--- a/cells/fill_diode/sky130_fd_sc_hs__fill_diode.symbol.pp.v
+++ b/cells/fill_diode/sky130_fd_sc_hs__fill_diode.symbol.pp.v
@@ -34,12 +34,10 @@
 (* blackbox *)
 module sky130_fd_sc_hs__fill_diode (
     //# {{power|Power}}
-    input VPB ,
     input VPWR,
     input  VGND,
     input  VPB ,
     input  VNB
-    input VNB
 );
 endmodule
 

--- a/cells/fill_diode/sky130_fd_sc_hs__fill_diode.symbol.v
+++ b/cells/fill_diode/sky130_fd_sc_hs__fill_diode.symbol.v
@@ -36,9 +36,7 @@ module sky130_fd_sc_hs__fill_diode ();
 
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
 

--- a/cells/fill_diode/sky130_fd_sc_hs__fill_diode_2.blackbox.v
+++ b/cells/fill_diode/sky130_fd_sc_hs__fill_diode_2.blackbox.v
@@ -34,9 +34,7 @@
 module sky130_fd_sc_hs__fill_diode_2 ();
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
 

--- a/cells/fill_diode/sky130_fd_sc_hs__fill_diode_2.functional.v
+++ b/cells/fill_diode/sky130_fd_sc_hs__fill_diode_2.functional.v
@@ -34,9 +34,7 @@ module sky130_fd_sc_hs__fill_diode_2 ();
 
     // Module supplies
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
      // No contents.

--- a/cells/fill_diode/sky130_fd_sc_hs__fill_diode_2.timing.v
+++ b/cells/fill_diode/sky130_fd_sc_hs__fill_diode_2.timing.v
@@ -34,9 +34,7 @@ module sky130_fd_sc_hs__fill_diode_2 ();
 
     // Module supplies
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
      // No contents.

--- a/cells/fill_diode/sky130_fd_sc_hs__fill_diode_4.blackbox.v
+++ b/cells/fill_diode/sky130_fd_sc_hs__fill_diode_4.blackbox.v
@@ -34,9 +34,7 @@
 module sky130_fd_sc_hs__fill_diode_4 ();
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
 

--- a/cells/fill_diode/sky130_fd_sc_hs__fill_diode_4.functional.v
+++ b/cells/fill_diode/sky130_fd_sc_hs__fill_diode_4.functional.v
@@ -34,9 +34,7 @@ module sky130_fd_sc_hs__fill_diode_4 ();
 
     // Module supplies
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
      // No contents.

--- a/cells/fill_diode/sky130_fd_sc_hs__fill_diode_4.timing.v
+++ b/cells/fill_diode/sky130_fd_sc_hs__fill_diode_4.timing.v
@@ -34,9 +34,7 @@ module sky130_fd_sc_hs__fill_diode_4 ();
 
     // Module supplies
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
      // No contents.

--- a/cells/fill_diode/sky130_fd_sc_hs__fill_diode_8.blackbox.v
+++ b/cells/fill_diode/sky130_fd_sc_hs__fill_diode_8.blackbox.v
@@ -34,9 +34,7 @@
 module sky130_fd_sc_hs__fill_diode_8 ();
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
 

--- a/cells/fill_diode/sky130_fd_sc_hs__fill_diode_8.functional.v
+++ b/cells/fill_diode/sky130_fd_sc_hs__fill_diode_8.functional.v
@@ -34,9 +34,7 @@ module sky130_fd_sc_hs__fill_diode_8 ();
 
     // Module supplies
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
      // No contents.

--- a/cells/fill_diode/sky130_fd_sc_hs__fill_diode_8.timing.v
+++ b/cells/fill_diode/sky130_fd_sc_hs__fill_diode_8.timing.v
@@ -34,9 +34,7 @@ module sky130_fd_sc_hs__fill_diode_8 ();
 
     // Module supplies
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
     supply1 VPB ;
     supply0 VNB ;
      // No contents.

--- a/cells/mux4/sky130_fd_sc_hs__mux4_1.functional.pp.v
+++ b/cells/mux4/sky130_fd_sc_hs__mux4_1.functional.pp.v
@@ -66,7 +66,7 @@ module sky130_fd_sc_hs__mux4_1 (
     wire    udp_pwrgood_pp$PG0_out_X;
 
     //                           Name          Output              Other arguments
-    sky130_fd_sc_hs__u_mux_4_2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
+    sky130_fd_sc_hs__udp_mux_4to2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
     sky130_fd_sc_hs__udp_pwrgood_pp$PG udp_pwrgood_pp$PG0 (udp_pwrgood_pp$PG0_out_X, u_mux_40_out_X, VPWR, VGND);
     buf                          buf0         (X                 , udp_pwrgood_pp$PG0_out_X        );
 

--- a/cells/mux4/sky130_fd_sc_hs__mux4_1.functional.v
+++ b/cells/mux4/sky130_fd_sc_hs__mux4_1.functional.v
@@ -62,7 +62,7 @@ module sky130_fd_sc_hs__mux4_1 (
     wire    udp_pwrgood_pp$PG0_out_X;
 
     //                           Name          Output              Other arguments
-    sky130_fd_sc_hs__u_mux_4_2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
+    sky130_fd_sc_hs__udp_mux_4to2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
     sky130_fd_sc_hs__udp_pwrgood_pp$PG udp_pwrgood_pp$PG0 (udp_pwrgood_pp$PG0_out_X, u_mux_40_out_X, VPWR, VGND);
     buf                          buf0         (X                 , udp_pwrgood_pp$PG0_out_X        );
 

--- a/cells/mux4/sky130_fd_sc_hs__mux4_1.timing.pp.v
+++ b/cells/mux4/sky130_fd_sc_hs__mux4_1.timing.pp.v
@@ -66,7 +66,7 @@ module sky130_fd_sc_hs__mux4_1 (
     wire    udp_pwrgood_pp$PG0_out_X;
 
     //                           Name          Output              Other arguments
-    sky130_fd_sc_hs__u_mux_4_2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
+    sky130_fd_sc_hs__udp_mux_4to2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
     sky130_fd_sc_hs__udp_pwrgood_pp$PG udp_pwrgood_pp$PG0 (udp_pwrgood_pp$PG0_out_X, u_mux_40_out_X, VPWR, VGND);
     buf                          buf0         (X                 , udp_pwrgood_pp$PG0_out_X        );
 

--- a/cells/mux4/sky130_fd_sc_hs__mux4_1.timing.v
+++ b/cells/mux4/sky130_fd_sc_hs__mux4_1.timing.v
@@ -62,7 +62,7 @@ module sky130_fd_sc_hs__mux4_1 (
     wire    udp_pwrgood_pp$PG0_out_X;
 
     //                           Name          Output              Other arguments
-    sky130_fd_sc_hs__u_mux_4_2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
+    sky130_fd_sc_hs__udp_mux_4to2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
     sky130_fd_sc_hs__udp_pwrgood_pp$PG udp_pwrgood_pp$PG0 (udp_pwrgood_pp$PG0_out_X, u_mux_40_out_X, VPWR, VGND);
     buf                          buf0         (X                 , udp_pwrgood_pp$PG0_out_X        );
 

--- a/cells/mux4/sky130_fd_sc_hs__mux4_2.functional.pp.v
+++ b/cells/mux4/sky130_fd_sc_hs__mux4_2.functional.pp.v
@@ -66,7 +66,7 @@ module sky130_fd_sc_hs__mux4_2 (
     wire    udp_pwrgood_pp$PG0_out_X;
 
     //                           Name          Output              Other arguments
-    sky130_fd_sc_hs__u_mux_4_2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
+    sky130_fd_sc_hs__udp_mux_4to2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
     sky130_fd_sc_hs__udp_pwrgood_pp$PG udp_pwrgood_pp$PG0 (udp_pwrgood_pp$PG0_out_X, u_mux_40_out_X, VPWR, VGND);
     buf                          buf0         (X                 , udp_pwrgood_pp$PG0_out_X        );
 

--- a/cells/mux4/sky130_fd_sc_hs__mux4_2.functional.v
+++ b/cells/mux4/sky130_fd_sc_hs__mux4_2.functional.v
@@ -62,7 +62,7 @@ module sky130_fd_sc_hs__mux4_2 (
     wire    udp_pwrgood_pp$PG0_out_X;
 
     //                           Name          Output              Other arguments
-    sky130_fd_sc_hs__u_mux_4_2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
+    sky130_fd_sc_hs__udp_mux_4to2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
     sky130_fd_sc_hs__udp_pwrgood_pp$PG udp_pwrgood_pp$PG0 (udp_pwrgood_pp$PG0_out_X, u_mux_40_out_X, VPWR, VGND);
     buf                          buf0         (X                 , udp_pwrgood_pp$PG0_out_X        );
 

--- a/cells/mux4/sky130_fd_sc_hs__mux4_2.timing.pp.v
+++ b/cells/mux4/sky130_fd_sc_hs__mux4_2.timing.pp.v
@@ -66,7 +66,7 @@ module sky130_fd_sc_hs__mux4_2 (
     wire    udp_pwrgood_pp$PG0_out_X;
 
     //                           Name          Output              Other arguments
-    sky130_fd_sc_hs__u_mux_4_2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
+    sky130_fd_sc_hs__udp_mux_4to2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
     sky130_fd_sc_hs__udp_pwrgood_pp$PG udp_pwrgood_pp$PG0 (udp_pwrgood_pp$PG0_out_X, u_mux_40_out_X, VPWR, VGND);
     buf                          buf0         (X                 , udp_pwrgood_pp$PG0_out_X        );
 

--- a/cells/mux4/sky130_fd_sc_hs__mux4_2.timing.v
+++ b/cells/mux4/sky130_fd_sc_hs__mux4_2.timing.v
@@ -62,7 +62,7 @@ module sky130_fd_sc_hs__mux4_2 (
     wire    udp_pwrgood_pp$PG0_out_X;
 
     //                           Name          Output              Other arguments
-    sky130_fd_sc_hs__u_mux_4_2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
+    sky130_fd_sc_hs__udp_mux_4to2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
     sky130_fd_sc_hs__udp_pwrgood_pp$PG udp_pwrgood_pp$PG0 (udp_pwrgood_pp$PG0_out_X, u_mux_40_out_X, VPWR, VGND);
     buf                          buf0         (X                 , udp_pwrgood_pp$PG0_out_X        );
 

--- a/cells/mux4/sky130_fd_sc_hs__mux4_4.functional.pp.v
+++ b/cells/mux4/sky130_fd_sc_hs__mux4_4.functional.pp.v
@@ -66,7 +66,7 @@ module sky130_fd_sc_hs__mux4_4 (
     wire    udp_pwrgood_pp$PG0_out_X;
 
     //                           Name          Output              Other arguments
-    sky130_fd_sc_hs__u_mux_4_2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
+    sky130_fd_sc_hs__udp_mux_4to2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
     sky130_fd_sc_hs__udp_pwrgood_pp$PG udp_pwrgood_pp$PG0 (udp_pwrgood_pp$PG0_out_X, u_mux_40_out_X, VPWR, VGND);
     buf                          buf0         (X                 , udp_pwrgood_pp$PG0_out_X        );
 

--- a/cells/mux4/sky130_fd_sc_hs__mux4_4.functional.v
+++ b/cells/mux4/sky130_fd_sc_hs__mux4_4.functional.v
@@ -62,7 +62,7 @@ module sky130_fd_sc_hs__mux4_4 (
     wire    udp_pwrgood_pp$PG0_out_X;
 
     //                           Name          Output              Other arguments
-    sky130_fd_sc_hs__u_mux_4_2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
+    sky130_fd_sc_hs__udp_mux_4to2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
     sky130_fd_sc_hs__udp_pwrgood_pp$PG udp_pwrgood_pp$PG0 (udp_pwrgood_pp$PG0_out_X, u_mux_40_out_X, VPWR, VGND);
     buf                          buf0         (X                 , udp_pwrgood_pp$PG0_out_X        );
 

--- a/cells/mux4/sky130_fd_sc_hs__mux4_4.timing.pp.v
+++ b/cells/mux4/sky130_fd_sc_hs__mux4_4.timing.pp.v
@@ -66,7 +66,7 @@ module sky130_fd_sc_hs__mux4_4 (
     wire    udp_pwrgood_pp$PG0_out_X;
 
     //                           Name          Output              Other arguments
-    sky130_fd_sc_hs__u_mux_4_2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
+    sky130_fd_sc_hs__udp_mux_4to2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
     sky130_fd_sc_hs__udp_pwrgood_pp$PG udp_pwrgood_pp$PG0 (udp_pwrgood_pp$PG0_out_X, u_mux_40_out_X, VPWR, VGND);
     buf                          buf0         (X                 , udp_pwrgood_pp$PG0_out_X        );
 

--- a/cells/mux4/sky130_fd_sc_hs__mux4_4.timing.v
+++ b/cells/mux4/sky130_fd_sc_hs__mux4_4.timing.v
@@ -62,7 +62,7 @@ module sky130_fd_sc_hs__mux4_4 (
     wire    udp_pwrgood_pp$PG0_out_X;
 
     //                           Name          Output              Other arguments
-    sky130_fd_sc_hs__u_mux_4_2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
+    sky130_fd_sc_hs__udp_mux_4to2   u_mux_40     (u_mux_40_out_X    , A0, A1, A2, A3, S0, S1    );
     sky130_fd_sc_hs__udp_pwrgood_pp$PG udp_pwrgood_pp$PG0 (udp_pwrgood_pp$PG0_out_X, u_mux_40_out_X, VPWR, VGND);
     buf                          buf0         (X                 , udp_pwrgood_pp$PG0_out_X        );
 

--- a/cells/tap/sky130_fd_sc_hs__tap.symbol.v
+++ b/cells/tap/sky130_fd_sc_hs__tap.symbol.v
@@ -36,9 +36,9 @@ module sky130_fd_sc_hs__tap ();
 
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
+    supply1 VPB ;
+    supply0 VNB ;
 
 endmodule
 

--- a/cells/tap/sky130_fd_sc_hs__tap_1.blackbox.pp.v
+++ b/cells/tap/sky130_fd_sc_hs__tap_1.blackbox.pp.v
@@ -32,16 +32,16 @@
 
 (* blackbox *)
 module sky130_fd_sc_hs__tap_1 (
-);,
     VPWR,
     VGND,
-    VPB ,
+    VPB,
     VNB
+);
 
     input  VPWR;
     input  VGND;
-    input  VPB ;
-    input  VNB ;
+    input  VPB;
+    input  VNB;
 endmodule
 
 `default_nettype wire

--- a/cells/tap/sky130_fd_sc_hs__tap_1.blackbox.v
+++ b/cells/tap/sky130_fd_sc_hs__tap_1.blackbox.v
@@ -32,11 +32,12 @@
 
 (* blackbox *)
 module sky130_fd_sc_hs__tap_1 ();
+
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
+    supply1 VPB ;
+    supply0 VNB ;
 
 endmodule
 

--- a/cells/tap/sky130_fd_sc_hs__tap_1.functional.pp.v
+++ b/cells/tap/sky130_fd_sc_hs__tap_1.functional.pp.v
@@ -32,12 +32,16 @@
 `celldefine
 module sky130_fd_sc_hs__tap_1 (
     VGND,
-    VPWR
+    VPWR,
+    VPB,
+    VNB
 );
 
     // Module ports
     input VGND;
     input VPWR;
+    input VPB;
+    input VNB;
      // No contents.
 endmodule
 `endcelldefine

--- a/cells/tap/sky130_fd_sc_hs__tap_1.functional.v
+++ b/cells/tap/sky130_fd_sc_hs__tap_1.functional.v
@@ -31,15 +31,17 @@
 
 `celldefine
 module sky130_fd_sc_hs__tap_1 (
-    VGND
 );
 
-    // Module ports
-    supply0 VGND;
+    // No module ports
 
     // Module supplies
+    supply0 VGND;
     supply1 VPWR;
-     // No contents.
+    supply0 VNB;
+    supply1 VPB;
+
+    // No contents.
 endmodule
 `endcelldefine
 

--- a/cells/tap/sky130_fd_sc_hs__tap_1.timing.pp.v
+++ b/cells/tap/sky130_fd_sc_hs__tap_1.timing.pp.v
@@ -32,12 +32,16 @@
 `celldefine
 module sky130_fd_sc_hs__tap_1 (
     VGND,
-    VPWR
+    VPWR,
+    VPB,
+    VNB
 );
 
     // Module ports
     input VGND;
     input VPWR;
+    input VPB;
+    input VNB;
      // No contents.
 endmodule
 `endcelldefine

--- a/cells/tap/sky130_fd_sc_hs__tap_1.timing.v
+++ b/cells/tap/sky130_fd_sc_hs__tap_1.timing.v
@@ -31,18 +31,15 @@
 
 `celldefine
 module sky130_fd_sc_hs__tap_1 (
-);,
-    VPWR,
-    VGND,
-    VPB ,
-    VNB
+);
 
-    // Module ports
-    input  VPWR;
-    input  VGND;
-    input  VPB ;
-    input  VNB ;
-     // No contents.
+    // Module supplies
+    supply1  VPWR;
+    supply0  VGND;
+    supply1  VPB;
+    supply0  VNB;
+
+    // No contents.
 endmodule
 `endcelldefine
 

--- a/cells/tap/sky130_fd_sc_hs__tap_2.blackbox.pp.v
+++ b/cells/tap/sky130_fd_sc_hs__tap_2.blackbox.pp.v
@@ -32,16 +32,17 @@
 
 (* blackbox *)
 module sky130_fd_sc_hs__tap_2 (
-);,
     VPWR,
     VGND,
-    VPB ,
+    VPB,
     VNB
+);
 
+    // Module ports
     input  VPWR;
     input  VGND;
-    input  VPB ;
-    input  VNB ;
+    input  VPB;
+    input  VNB;
 endmodule
 
 `default_nettype wire

--- a/cells/tap/sky130_fd_sc_hs__tap_2.blackbox.v
+++ b/cells/tap/sky130_fd_sc_hs__tap_2.blackbox.v
@@ -32,11 +32,12 @@
 
 (* blackbox *)
 module sky130_fd_sc_hs__tap_2 ();
+
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
+    supply1 VPB;
+    supply0 VNB;
 
 endmodule
 

--- a/cells/tap/sky130_fd_sc_hs__tap_2.functional.pp.v
+++ b/cells/tap/sky130_fd_sc_hs__tap_2.functional.pp.v
@@ -32,12 +32,16 @@
 `celldefine
 module sky130_fd_sc_hs__tap_2 (
     VGND,
-    VPWR
+    VPWR,
+    VPB,
+    VNB
 );
 
     // Module ports
     input VGND;
     input VPWR;
+    input VPB;
+    input VNB;
      // No contents.
 endmodule
 `endcelldefine

--- a/cells/tap/sky130_fd_sc_hs__tap_2.functional.v
+++ b/cells/tap/sky130_fd_sc_hs__tap_2.functional.v
@@ -31,15 +31,17 @@
 
 `celldefine
 module sky130_fd_sc_hs__tap_2 (
-    VGND
 );
 
-    // Module ports
-    supply0 VGND;
+    // No module ports
 
     // Module supplies
+    supply0 VGND;
     supply1 VPWR;
-     // No contents.
+    supply0 VPB;
+    supply1 VNB;
+
+    // No contents.
 endmodule
 `endcelldefine
 

--- a/cells/tap/sky130_fd_sc_hs__tap_2.timing.pp.v
+++ b/cells/tap/sky130_fd_sc_hs__tap_2.timing.pp.v
@@ -32,12 +32,16 @@
 `celldefine
 module sky130_fd_sc_hs__tap_2 (
     VGND,
-    VPWR
+    VPWR,
+    VPB,
+    VNB
 );
 
     // Module ports
     input VGND;
     input VPWR;
+    input VPB;
+    input VNB;
      // No contents.
 endmodule
 `endcelldefine

--- a/cells/tap/sky130_fd_sc_hs__tap_2.timing.v
+++ b/cells/tap/sky130_fd_sc_hs__tap_2.timing.v
@@ -31,18 +31,16 @@
 
 `celldefine
 module sky130_fd_sc_hs__tap_2 (
-);,
-    VPWR,
-    VGND,
-    VPB ,
-    VNB
+);
+    // No module ports
 
-    // Module ports
-    input  VPWR;
-    input  VGND;
-    input  VPB ;
-    input  VNB ;
-     // No contents.
+    // Module supplies
+    supply1  VPWR;
+    supply0  VGND;
+    supply1  VPB;
+    supply0  VNB;
+
+    // No contents.
 endmodule
 `endcelldefine
 

--- a/cells/tapmet1/sky130_fd_sc_hs__tapmet1.symbol.v
+++ b/cells/tapmet1/sky130_fd_sc_hs__tapmet1.symbol.v
@@ -36,9 +36,9 @@ module sky130_fd_sc_hs__tapmet1 ();
 
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
+    supply1 VPB ;
+    supply0 VNB ;
 
 endmodule
 

--- a/cells/tapmet1/sky130_fd_sc_hs__tapmet1_2.blackbox.pp.v
+++ b/cells/tapmet1/sky130_fd_sc_hs__tapmet1_2.blackbox.pp.v
@@ -32,11 +32,11 @@
 
 (* blackbox *)
 module sky130_fd_sc_hs__tapmet1_2 (
-);,
     VPWR,
     VGND,
     VPB ,
     VNB
+);
 
     input  VPWR;
     input  VGND;

--- a/cells/tapmet1/sky130_fd_sc_hs__tapmet1_2.blackbox.v
+++ b/cells/tapmet1/sky130_fd_sc_hs__tapmet1_2.blackbox.v
@@ -32,11 +32,12 @@
 
 (* blackbox *)
 module sky130_fd_sc_hs__tapmet1_2 ();
+
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
+    supply1 VPB ;
+    supply0 VNB ;
 
 endmodule
 

--- a/cells/tapmet1/sky130_fd_sc_hs__tapmet1_2.functional.pp.v
+++ b/cells/tapmet1/sky130_fd_sc_hs__tapmet1_2.functional.pp.v
@@ -32,12 +32,16 @@
 `celldefine
 module sky130_fd_sc_hs__tapmet1_2 (
     VGND,
-    VPWR
+    VPWR,
+    VPB,
+    VNB
 );
 
     // Module ports
     input VGND;
     input VPWR;
+    input VPB;
+    input VNB;
      // No contents.
 endmodule
 `endcelldefine

--- a/cells/tapmet1/sky130_fd_sc_hs__tapmet1_2.functional.v
+++ b/cells/tapmet1/sky130_fd_sc_hs__tapmet1_2.functional.v
@@ -31,14 +31,15 @@
 
 `celldefine
 module sky130_fd_sc_hs__tapmet1_2 (
-    VGND
 );
 
-    // Module ports
-    supply0 VGND;
+    // No module ports
 
     // Module supplies
+    supply0 VGND;
     supply1 VPWR;
+    supply0 VNB;
+    supply1 VPB;
      // No contents.
 endmodule
 `endcelldefine

--- a/cells/tapmet1/sky130_fd_sc_hs__tapmet1_2.timing.pp.v
+++ b/cells/tapmet1/sky130_fd_sc_hs__tapmet1_2.timing.pp.v
@@ -32,12 +32,16 @@
 `celldefine
 module sky130_fd_sc_hs__tapmet1_2 (
     VGND,
-    VPWR
+    VPWR,
+    VPB,
+    VNB
 );
 
     // Module ports
     input VGND;
     input VPWR;
+    input VPB;
+    input VNB;
      // No contents.
 endmodule
 `endcelldefine

--- a/cells/tapmet1/sky130_fd_sc_hs__tapmet1_2.timing.v
+++ b/cells/tapmet1/sky130_fd_sc_hs__tapmet1_2.timing.v
@@ -31,17 +31,15 @@
 
 `celldefine
 module sky130_fd_sc_hs__tapmet1_2 (
-);,
-    VPWR,
-    VGND,
-    VPB ,
-    VNB
+);
 
-    // Module ports
-    input  VPWR;
-    input  VGND;
-    input  VPB ;
-    input  VNB ;
+    // No module ports
+
+    // Module supplies
+    supply1  VPWR;
+    supply0  VGND;
+    supply1  VPB ;
+    supply0  VNB ;
      // No contents.
 endmodule
 `endcelldefine

--- a/cells/tapvgnd/sky130_fd_sc_hs__tapvgnd.symbol.pp.v
+++ b/cells/tapvgnd/sky130_fd_sc_hs__tapvgnd.symbol.pp.v
@@ -37,8 +37,7 @@ module sky130_fd_sc_hs__tapvgnd (
     //# {{power|Power}}
     input VPWR,
     input  VGND,
-    input  VPB ,
-    input  VNB
+    input  VPB
 );
 endmodule
 

--- a/cells/tapvgnd/sky130_fd_sc_hs__tapvgnd.symbol.v
+++ b/cells/tapvgnd/sky130_fd_sc_hs__tapvgnd.symbol.v
@@ -37,9 +37,8 @@ module sky130_fd_sc_hs__tapvgnd ();
 
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
+    supply1 VPB;
 
 endmodule
 

--- a/cells/tapvgnd/sky130_fd_sc_hs__tapvgnd_1.blackbox.pp.v
+++ b/cells/tapvgnd/sky130_fd_sc_hs__tapvgnd_1.blackbox.pp.v
@@ -33,16 +33,14 @@
 
 (* blackbox *)
 module sky130_fd_sc_hs__tapvgnd_1 (
-);,
     VPWR,
     VGND,
-    VPB ,
-    VNB
+    VPB
+);
 
     input  VPWR;
     input  VGND;
     input  VPB ;
-    input  VNB ;
 endmodule
 
 `default_nettype wire

--- a/cells/tapvgnd/sky130_fd_sc_hs__tapvgnd_1.blackbox.v
+++ b/cells/tapvgnd/sky130_fd_sc_hs__tapvgnd_1.blackbox.v
@@ -33,15 +33,13 @@
 
 (* blackbox *)
 module sky130_fd_sc_hs__tapvgnd_1 ();
+
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
+    supply1 VPB;
 
 endmodule
 
 `default_nettype wire
 `endif  // SKY130_FD_SC_HS__TAPVGND_1_BLACKBOX_V
-    input  VPB ;
-    input  VNB ;

--- a/cells/tapvgnd/sky130_fd_sc_hs__tapvgnd_1.functional.pp.v
+++ b/cells/tapvgnd/sky130_fd_sc_hs__tapvgnd_1.functional.pp.v
@@ -33,12 +33,14 @@
 `celldefine
 module sky130_fd_sc_hs__tapvgnd_1 (
     VGND,
-    VPWR
+    VPWR,
+    VPB
 );
 
     // Module ports
     input VGND;
     input VPWR;
+    input VPB;
      // No contents.
 endmodule
 `endcelldefine

--- a/cells/tapvgnd/sky130_fd_sc_hs__tapvgnd_1.functional.v
+++ b/cells/tapvgnd/sky130_fd_sc_hs__tapvgnd_1.functional.v
@@ -32,14 +32,14 @@
 
 `celldefine
 module sky130_fd_sc_hs__tapvgnd_1 (
-    VGND
 );
 
-    // Module ports
-    supply0 VGND;
+    // No module ports
 
     // Module supplies
+    supply0 VGND;
     supply1 VPWR;
+    supply1 VPB;
      // No contents.
 endmodule
 `endcelldefine

--- a/cells/tapvgnd/sky130_fd_sc_hs__tapvgnd_1.timing.pp.v
+++ b/cells/tapvgnd/sky130_fd_sc_hs__tapvgnd_1.timing.pp.v
@@ -33,12 +33,14 @@
 `celldefine
 module sky130_fd_sc_hs__tapvgnd_1 (
     VGND,
-    VPWR
+    VPWR,
+    VPB
 );
 
     // Module ports
     input VGND;
     input VPWR;
+    input VPB;
      // No contents.
 endmodule
 `endcelldefine

--- a/cells/tapvgnd/sky130_fd_sc_hs__tapvgnd_1.timing.v
+++ b/cells/tapvgnd/sky130_fd_sc_hs__tapvgnd_1.timing.v
@@ -32,17 +32,14 @@
 
 `celldefine
 module sky130_fd_sc_hs__tapvgnd_1 (
-);,
-    VPWR,
-    VGND,
-    VPB ,
-    VNB
+);
+    // No module ports
 
-    // Module ports
-    input  VPWR;
-    input  VGND;
-    input  VPB ;
-    input  VNB ;
+    // Module supplies
+    supply1  VPWR;
+    supply0  VGND;
+    supply1  VPB ;
+
      // No contents.
 endmodule
 `endcelldefine

--- a/cells/tapvgnd2/sky130_fd_sc_hs__tapvgnd2.symbol.pp.v
+++ b/cells/tapvgnd2/sky130_fd_sc_hs__tapvgnd2.symbol.pp.v
@@ -37,8 +37,7 @@ module sky130_fd_sc_hs__tapvgnd2 (
     //# {{power|Power}}
     input VPWR,
     input  VGND,
-    input  VPB ,
-    input  VNB
+    input  VPB
 );
 endmodule
 

--- a/cells/tapvgnd2/sky130_fd_sc_hs__tapvgnd2.symbol.v
+++ b/cells/tapvgnd2/sky130_fd_sc_hs__tapvgnd2.symbol.v
@@ -37,13 +37,10 @@ module sky130_fd_sc_hs__tapvgnd2 ();
 
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
+    supply1 VPB ;
 
 endmodule
 
 `default_nettype wire
 `endif  // SKY130_FD_SC_HS__TAPVGND2_SYMBOL_V
-    input  VPB ;
-    input  VNB ;

--- a/cells/tapvgnd2/sky130_fd_sc_hs__tapvgnd2_1.blackbox.pp.v
+++ b/cells/tapvgnd2/sky130_fd_sc_hs__tapvgnd2_1.blackbox.pp.v
@@ -33,16 +33,14 @@
 
 (* blackbox *)
 module sky130_fd_sc_hs__tapvgnd2_1 (
-);,
     VPWR,
     VGND,
-    VPB ,
-    VNB
+    VPB
+);
 
     input  VPWR;
     input  VGND;
     input  VPB ;
-    input  VNB ;
 endmodule
 
 `default_nettype wire

--- a/cells/tapvgnd2/sky130_fd_sc_hs__tapvgnd2_1.blackbox.v
+++ b/cells/tapvgnd2/sky130_fd_sc_hs__tapvgnd2_1.blackbox.v
@@ -33,15 +33,13 @@
 
 (* blackbox *)
 module sky130_fd_sc_hs__tapvgnd2_1 ();
+
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
+    supply1 VPB ;
 
 endmodule
 
 `default_nettype wire
 `endif  // SKY130_FD_SC_HS__TAPVGND2_1_BLACKBOX_V
-    input  VPB ;
-    input  VNB ;

--- a/cells/tapvgnd2/sky130_fd_sc_hs__tapvgnd2_1.functional.pp.v
+++ b/cells/tapvgnd2/sky130_fd_sc_hs__tapvgnd2_1.functional.pp.v
@@ -33,12 +33,14 @@
 `celldefine
 module sky130_fd_sc_hs__tapvgnd2_1 (
     VGND,
-    VPWR
+    VPWR,
+    VPB
 );
 
     // Module ports
     input VGND;
     input VPWR;
+    input VPB;
      // No contents.
 endmodule
 `endcelldefine

--- a/cells/tapvgnd2/sky130_fd_sc_hs__tapvgnd2_1.functional.v
+++ b/cells/tapvgnd2/sky130_fd_sc_hs__tapvgnd2_1.functional.v
@@ -32,14 +32,14 @@
 
 `celldefine
 module sky130_fd_sc_hs__tapvgnd2_1 (
-    VGND
 );
 
-    // Module ports
-    supply0 VGND;
+    // No module ports
 
     // Module supplies
+    supply0 VGND;
     supply1 VPWR;
+    supply1 VPB;
      // No contents.
 endmodule
 `endcelldefine

--- a/cells/tapvgnd2/sky130_fd_sc_hs__tapvgnd2_1.timing.pp.v
+++ b/cells/tapvgnd2/sky130_fd_sc_hs__tapvgnd2_1.timing.pp.v
@@ -33,12 +33,14 @@
 `celldefine
 module sky130_fd_sc_hs__tapvgnd2_1 (
     VGND,
-    VPWR
+    VPWR,
+    VPB
 );
 
     // Module ports
     input VGND;
     input VPWR;
+    input VPB;
      // No contents.
 endmodule
 `endcelldefine

--- a/cells/tapvgnd2/sky130_fd_sc_hs__tapvgnd2_1.timing.v
+++ b/cells/tapvgnd2/sky130_fd_sc_hs__tapvgnd2_1.timing.v
@@ -32,18 +32,16 @@
 
 `celldefine
 module sky130_fd_sc_hs__tapvgnd2_1 (
-);,
-    VPWR,
-    VGND,
-    VPB ,
-    VNB
+);
 
-    // Module ports
-    input  VPWR;
-    input  VGND;
-    input  VPB ;
-    input  VNB ;
-     // No contents.
+    // No module ports
+
+    // Module supplies
+    supply1  VPWR;
+    supply0  VGND;
+    supply1  VPB ;
+
+    // No contents.
 endmodule
 `endcelldefine
 

--- a/cells/tapvpwrvgnd/sky130_fd_sc_hs__tapvpwrvgnd.symbol.pp.v
+++ b/cells/tapvpwrvgnd/sky130_fd_sc_hs__tapvpwrvgnd.symbol.pp.v
@@ -35,9 +35,7 @@
 module sky130_fd_sc_hs__tapvpwrvgnd (
     //# {{power|Power}}
     input VPWR,
-    input  VGND,
-    input  VPB ,
-    input  VNB
+    input VGND
 );
 endmodule
 

--- a/cells/tapvpwrvgnd/sky130_fd_sc_hs__tapvpwrvgnd.symbol.v
+++ b/cells/tapvpwrvgnd/sky130_fd_sc_hs__tapvpwrvgnd.symbol.v
@@ -36,13 +36,9 @@ module sky130_fd_sc_hs__tapvpwrvgnd ();
 
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
 
 endmodule
 
 `default_nettype wire
 `endif  // SKY130_FD_SC_HS__TAPVPWRVGND_SYMBOL_V
-    input  VPB ;
-    input  VNB ;

--- a/cells/tapvpwrvgnd/sky130_fd_sc_hs__tapvpwrvgnd_1.blackbox.pp.v
+++ b/cells/tapvpwrvgnd/sky130_fd_sc_hs__tapvpwrvgnd_1.blackbox.pp.v
@@ -32,16 +32,12 @@
 
 (* blackbox *)
 module sky130_fd_sc_hs__tapvpwrvgnd_1 (
-);,
     VPWR,
-    VGND,
-    VPB ,
-    VNB
+    VGND
+);
 
     input  VPWR;
     input  VGND;
-    input  VPB ;
-    input  VNB ;
 endmodule
 
 `default_nettype wire

--- a/cells/tapvpwrvgnd/sky130_fd_sc_hs__tapvpwrvgnd_1.blackbox.v
+++ b/cells/tapvpwrvgnd/sky130_fd_sc_hs__tapvpwrvgnd_1.blackbox.v
@@ -32,15 +32,12 @@
 
 (* blackbox *)
 module sky130_fd_sc_hs__tapvpwrvgnd_1 ();
+
     // Voltage supply signals
     supply1 VPWR;
-    VGND,
-    VPB ,
-    VNB
+    supply0 VGND;
 
 endmodule
 
 `default_nettype wire
 `endif  // SKY130_FD_SC_HS__TAPVPWRVGND_1_BLACKBOX_V
-    input  VPB ;
-    input  VNB ;

--- a/cells/tapvpwrvgnd/sky130_fd_sc_hs__tapvpwrvgnd_1.functional.v
+++ b/cells/tapvpwrvgnd/sky130_fd_sc_hs__tapvpwrvgnd_1.functional.v
@@ -31,15 +31,15 @@
 
 `celldefine
 module sky130_fd_sc_hs__tapvpwrvgnd_1 (
-    VGND
 );
 
-    // Module ports
-    supply0 VGND;
+    // No module ports
 
     // Module supplies
+    supply0 VGND;
     supply1 VPWR;
-     // No contents.
+
+    // No contents.
 endmodule
 `endcelldefine
 

--- a/cells/tapvpwrvgnd/sky130_fd_sc_hs__tapvpwrvgnd_1.timing.v
+++ b/cells/tapvpwrvgnd/sky130_fd_sc_hs__tapvpwrvgnd_1.timing.v
@@ -31,18 +31,14 @@
 
 `celldefine
 module sky130_fd_sc_hs__tapvpwrvgnd_1 (
-);,
-    VPWR,
-    VGND,
-    VPB ,
-    VNB
+);
+    // No module ports
 
-    // Module ports
-    input  VPWR;
-    input  VGND;
-    input  VPB ;
-    input  VNB ;
-     // No contents.
+    // Module supplies
+    supply1  VPWR;
+    supply0  VGND;
+
+    // No contents.
 endmodule
 `endcelldefine
 


### PR DESCRIPTION
Second set of fixes to the HS library verilog files.  Most of the fixes are to cells that have slightly different syntax than most of the standard cells, like tap and decap cells, for which the lack of signals in the header made them incompatible with the script that I used for the first set of fixes.  The resulting verilog has been carefully checked this time using iverilog as a parser/linter, with all four permutations of USE_POWER_PINS and FUNCTIONAL definitions tested.