### PR TITLE
removing signals listed outside module

### DIFF
--- a/cells/tapvgnd/sky130_fd_sc_hs__tapvgnd.symbol.v
+++ b/cells/tapvgnd/sky130_fd_sc_hs__tapvgnd.symbol.v
@@ -44,5 +44,3 @@ endmodule
 
 `default_nettype wire
 `endif  // SKY130_FD_SC_HS__TAPVGND_SYMBOL_V
-    input wire wire  VPB ;
-    input wire wire  VNB ;


### PR DESCRIPTION
Seems like an error withing a large scripted edit.

The affected Verilog code is just and is not used by synthesis/... tools.